### PR TITLE
Pass original submission to email template

### DIFF
--- a/src/ContactFormExtensions.php
+++ b/src/ContactFormExtensions.php
@@ -108,7 +108,7 @@ class ContactFormExtensions extends Plugin
                 // Render the set template
                 $html = Craft::$app->view->renderTemplate(
                     $this->settings->notificationTemplate,
-                    ['submission' => $submission]
+                    ['submission' => $e->submission]
                 );
 
                 // Update the message body


### PR DESCRIPTION
Ran into a problem where if I have extra fields(say phone number) in the message field that I want to include in the email template I can't do it because the message field returned from contactFormExtensionsService->saveSubmission() is json_encoded.

I think you could just return the original event submission here, works fine in the confirmation event.