### PR TITLE
Allow a custom form name

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,11 @@ When you overwrite the email templates, your twig view will receive a `submissio
 - message
 - attachment
 
+## Overriding the form name
+When saving submissions to the database the default form name will be "Contact". If you add a `message[formName]` hidden field you can override the form name. This can also used to create multiple form indexes in the Control Panel.
+
+```
+<input type="hidden" name="message[formName]" value="myFormName">
+```
+
 Brought to you by [Rias](https://rias.be)

--- a/src/services/ContactFormExtensionsService.php
+++ b/src/services/ContactFormExtensionsService.php
@@ -55,7 +55,7 @@ class ContactFormExtensionsService extends Component
     public function saveSubmission(Submission $submission)
     {
         $contactFormSubmission = new ContactFormSubmission();
-        $contactFormSubmission->form = 'contact';
+        $contactFormSubmission->form = $submission->message['formName'] ?? 'contact';
         $contactFormSubmission->fromName = $submission->fromName;
         $contactFormSubmission->fromEmail = $submission->fromEmail;
         $contactFormSubmission->subject = $submission->subject;


### PR DESCRIPTION
It'd be nice to be able to pass a custom form name when saving submissions. That way the saved entries are broken up by form name in the admin.

The only way I could think of doing it was passing it through the message field though. Seems to work just fine but doesn't feel ideal.

This solution could work by adding a hidden field to the form:
`<input type="hidden" name="message[formName]" value="foo">`