### PR TITLE
Fix for checkbox and radio inputs

### DIFF
--- a/src/elements/ContactFormSubmission.php
+++ b/src/elements/ContactFormSubmission.php
@@ -161,8 +161,10 @@ class ContactFormSubmission extends Element
             $message = (array) json_decode($this->message);
             $html = '<ul>';
             foreach ($message as $key => $value) {
-                $shortened = trim(substr($value, 0, 30));
-                $html .= "<li><em>{$key}</em>: {$shortened}...</li>";
+                if (is_string($value)) {
+                    $shortened = trim(substr($value, 0, 30));
+                    $html .= "<li><em>{$key}</em>: {$shortened}...</li>";
+                }
             }
             $html .= '</ul>';
 

--- a/src/templates/submissions/_show.twig
+++ b/src/templates/submissions/_show.twig
@@ -29,7 +29,13 @@
         <p>{{ submission.fromEmail }}</p>
         {% for key, value in messageObject %}
             <h3>{{ key|ucfirst }}</h3>
-            <p>{{ value }}</p>
+            {% if value is iterable %}
+                {% for item in value %}
+                    <p>{{ item }}</p>
+                {% endfor %}
+            {% else %}
+                <p>{{ value }}</p>
+            {% endif %}
         {% endfor %}
     </div>
 


### PR DESCRIPTION
Ran into a problem with radio/checkbox inputs, which wind up as arrays in the message object. There's two places that assume the value is a string and would fail with an unknown error.

- The first place was in the getTableAttributeHtml function. I'm simply excluded anything that isn't a string.
- The second was in the submission show template. That will just loop over anything iterable now. 

Example inputs:
```
<label><input type="radio" name="message[Services][]" value="Design"> Design</label>
<label><input type="radio" name="message[Services][]" value="Development"> Development</label>
```

