### PR TITLE
Translate 'all submissions' term from header

### DIFF
--- a/src/elements/ContactFormSubmission.php
+++ b/src/elements/ContactFormSubmission.php
@@ -111,7 +111,7 @@ class ContactFormSubmission extends Element
         $sources = [
             [
                 'key'      => '*',
-                'label'    => 'All submissions',
+                'label'    => Craft::t('contact-form-extensions', 'All submissions'),
                 'criteria' => [],
             ],
         ];


### PR DESCRIPTION
#14 

You cannot translate the terms "All submissions" and "Submissions" in the header (under form submissions in the main menu: https://cl.ly/2N1i3S3s362d), unlike the rest of the terms in the plugin.

This pull request just adds the necessary "Craft::t" call. 

(First pull request, so plz be kind 🙈)