### PR TITLE
Add support for Craft 3.1's environmental settings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^3.0.0-RC1",
+        "craftcms/cms": "^3.1",
         "craftcms/contact-form": "^2.1",
         "albertcht/invisible-recaptcha": "^1.8"
     },

--- a/src/services/ContactFormExtensionsService.php
+++ b/src/services/ContactFormExtensionsService.php
@@ -78,8 +78,8 @@ class ContactFormExtensionsService extends Component
 
     public function getRecaptcha()
     {
-        $siteKey = ContactFormExtensions::$plugin->settings->recaptchaSiteKey;
-        $secretKey = ContactFormExtensions::$plugin->settings->recaptchaSecretKey;
+        $siteKey = Craft::parseEnv(ContactFormExtensions::$plugin->settings->recaptchaSiteKey);
+        $secretKey = Craft::parseEnv(ContactFormExtensions::$plugin->settings->recaptchaSecretKey);
         $options = [
             'hideBadge' => ContactFormExtensions::$plugin->settings->recaptchaHideBadge,
             'dataBadge' => ContactFormExtensions::$plugin->settings->recaptchaDataBadge,

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -105,7 +105,7 @@
     }) }}
 
     <div id="recaptchaSettings" {% if not settings.recaptcha %}class="hidden"{% endif %}>
-        {{ forms.textField({
+        {{ forms.autosuggestField({
             label: 'Site Key',
             instructions: 'Recaptcha Site Key',
             id: 'recaptchaSiteKey',
@@ -113,16 +113,18 @@
             disabled:     'recaptchaSiteKey' in overrides,
             warning:      'recaptchaSiteKey' in overrides ? configWarning('recaptchaSiteKey'),
             value: settings.recaptchaSiteKey,
+            suggestEnvVars: true,
         }) }}
 
-        {{ forms.textField({
+        {{ forms.autosuggestField({
             label: 'Secret Key',
-            instructions: 'Recaptcha Site Key',
+            instructions: 'Recaptcha Secret Key',
             id: 'recaptchaSecretKey',
             name: 'recaptchaSecretKey',
             disabled:     'recaptchaSecretKey' in overrides,
             warning:      'recaptchaSecretKey' in overrides ? configWarning('recaptchaSecretKey'),
             value: settings.recaptchaSecretKey,
+            suggestEnvVars: true,
         }) }}
 
         {{ forms.lightswitchField({


### PR DESCRIPTION
This PR adds support for Craft 3.1's [environmental settings feature](https://docs.craftcms.com/v3/config/environments.html#control-panel-settings) for the `recaptchaSiteKey` and `recaptchaSecretKey` settings. Please note that it increases the minimum Craft version to 3.1.

Fixes #39 