### PR TITLE
Bugfix: Always send mails from the same address

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ When saving submissions to the database the default form name will be "Contact".
 <input type="hidden" name="message[formName]" value="myFormName">
 ```
 
+## Overriding the confirmation template
+When sending confirmation option is enabled and custom templates per form are needed, override the template with a hidden field. The template needs to be placed under templates\\_emails folder. Add a hash for safety. The same data is passed as in the default overridden template.
+
+```
+<input type="hidden" name="message[template]" value="{{ 'contact'|hash }}">
+```
+
 ## Adding invisible reCAPTCHA
 
 Before you set your config, remember to choose `invisible reCAPTCHA` while applying for keys.

--- a/src/ContactFormExtensions.php
+++ b/src/ContactFormExtensions.php
@@ -158,7 +158,7 @@ class ContactFormExtensions extends Plugin
                 // Create the confirmation email
                 $message = new Message();
                 $message->setTo($e->submission->fromEmail);
-                $message->setFrom($e->message->getTo());
+                $message->setFrom($e->message->getFrom());
                 $message->setHtmlBody($html);
                 $message->setSubject($this->settings->getConfirmationSubject());
 

--- a/src/ContactFormExtensions.php
+++ b/src/ContactFormExtensions.php
@@ -12,13 +12,13 @@
 namespace rias\contactformextensions;
 
 use Craft;
-use craft\helpers\App;
 use craft\base\Plugin;
 use craft\contactform\events\SendEvent;
 use craft\contactform\Mailer;
 use craft\contactform\models\Submission;
 use craft\events\RegisterUrlRulesEvent;
 use craft\events\TemplateEvent;
+use craft\helpers\App;
 use craft\mail\Message;
 use craft\services\Plugins;
 use craft\web\twig\variables\CraftVariable;
@@ -152,8 +152,8 @@ class ContactFormExtensions extends Plugin
 
                 // Check if tempplate is overridden in form
                 $template = null;
-                if(array_key_exists('template', $e->submission->message)) {
-                    $template = '_emails\\' . Craft::$app->security->validateData($e->submission->message['template']);
+                if (array_key_exists('template', $e->submission->message)) {
+                    $template = '_emails\\'.Craft::$app->security->validateData($e->submission->message['template']);
                 } else {
                     // Render the set template
                     $template = $this->settings->confirmationTemplate;
@@ -166,7 +166,7 @@ class ContactFormExtensions extends Plugin
                 // Create the confirmation email
                 $message = new Message();
                 $message->setTo($e->submission->fromEmail);
-                if(isset(App::mailSettings()->fromEmail)) {
+                if (isset(App::mailSettings()->fromEmail)) {
                     $message->setFrom(App::mailSettings()->fromEmail);
                 } else {
                     $message->setFrom($e->message->getTo());

--- a/src/ContactFormExtensions.php
+++ b/src/ContactFormExtensions.php
@@ -149,16 +149,26 @@ class ContactFormExtensions extends Plugin
                 // First set the template mode to the Site templates
                 Craft::$app->view->setTemplateMode(View::TEMPLATE_MODE_SITE);
 
-                // Render the set template
+                // Check if tempplate is overridden in form
+                $template = null;
+                if(array_key_exists("template", $e->submission->message)) {
+                    $template = "_emails\\" . Craft::$app->security->validateData($e->submission->message['template']);
+                } else {
+                    // Render the set template
+                    $template = $this->settings->confirmationTemplate;
+                }
                 $html = Craft::$app->view->renderTemplate(
-                    $this->settings->confirmationTemplate,
+                    $template,
                     ['submission' => $e->submission]
                 );
 
                 // Create the confirmation email
                 $message = new Message();
                 $message->setTo($e->submission->fromEmail);
-                $message->setFrom($e->message->getFrom());
+                if(isset(App::mailSettings()->fromEmail))
+                    $message->setFrom(App::mailSettings()->fromEmail);
+                else
+                    $message->setFrom($e->message->getTo());
                 $message->setHtmlBody($html);
                 $message->setSubject($this->settings->getConfirmationSubject());
 

--- a/src/ContactFormExtensions.php
+++ b/src/ContactFormExtensions.php
@@ -12,6 +12,7 @@
 namespace rias\contactformextensions;
 
 use Craft;
+use craft\helpers\App;
 use craft\base\Plugin;
 use craft\contactform\events\SendEvent;
 use craft\contactform\Mailer;
@@ -151,8 +152,8 @@ class ContactFormExtensions extends Plugin
 
                 // Check if tempplate is overridden in form
                 $template = null;
-                if(array_key_exists("template", $e->submission->message)) {
-                    $template = "_emails\\" . Craft::$app->security->validateData($e->submission->message['template']);
+                if(array_key_exists('template', $e->submission->message)) {
+                    $template = '_emails\\' . Craft::$app->security->validateData($e->submission->message['template']);
                 } else {
                     // Render the set template
                     $template = $this->settings->confirmationTemplate;
@@ -165,10 +166,11 @@ class ContactFormExtensions extends Plugin
                 // Create the confirmation email
                 $message = new Message();
                 $message->setTo($e->submission->fromEmail);
-                if(isset(App::mailSettings()->fromEmail))
+                if(isset(App::mailSettings()->fromEmail)) {
                     $message->setFrom(App::mailSettings()->fromEmail);
-                else
+                } else {
                     $message->setFrom($e->message->getTo());
+                }
                 $message->setHtmlBody($html);
                 $message->setSubject($this->settings->getConfirmationSubject());
 


### PR DESCRIPTION
If the mailaddress configured in Craft's mail settings to send mails from differs from the mailaddress notification address, this results in an error. Craft can't send mails from other mailaddresses that are not configured.